### PR TITLE
Add fuzzy option to cmd_show

### DIFF
--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -320,9 +320,8 @@ cmd_show() {
 			shift
 		done
 		local num_result=$(wc -l < "$matches_file" | xargs)
-		local matches=$(cat "$matches_file")
-		rm -f "$matches_file" "$matches_file_swap"
 		if [[ $num_result -eq 0 ]]; then
+			rm -f "$matches_file" "$matches_file_swap"
 			die "No matching password found for $orig_query"
 		elif [[ $num_result -gt 1 ]]; then
 			echo
@@ -331,12 +330,14 @@ cmd_show() {
 			else
 				echo "$num_result passwords in database:"
 			fi
-			echo "$matches"
+			cat "$matches_file"
 			echo
+			rm -f "$matches_file" "$matches_file_swap"
 			die "Try adding more words to narrow down."
 		else
-			path=$(echo "$matches" | perl -pe 's/\e\[?.*?[\@-~]//g')
-			echo "Retrieving password for $matches"
+			path=$(cat "$matches_file" | perl -pe 's/\e\[?.*?[\@-~]//g')
+			echo "Retrieving password for $(cat "$matches_files")"
+			rm -f "$matches_file" "$matches_file_swap"
 		fi
 	fi
 	local passfile="$PREFIX/$path.gpg"

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -312,7 +312,7 @@ cmd_show() {
 	if [[ $fuzzy -eq 1 ]]; then
 		local orig_query="$@"
 		cd "$PREFIX"
-		local -a matches matches_copy
+		local matches matches_copy
 		matches=$(find . -type f | grep '\.gpg$' | sed -e 's/^\.\///g' | sed -e 's/\.gpg$//g')
 		while [[ $# -gt 0 ]]; do
 			matches_copy="$matches"

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -336,7 +336,7 @@ cmd_show() {
 			die "Try adding more words to narrow down."
 		else
 			path=$(cat "$matches_file" | perl -pe 's/\e\[?.*?[\@-~]//g')
-			echo "Retrieving password for $(cat "$matches_files")"
+			echo "Retrieving password for $(cat "$matches_file")"
 			rm -f "$matches_file" "$matches_file_swap"
 		fi
 	fi


### PR DESCRIPTION
When "show" command is invoked with --fuzzy or -f, the last arguments
are treated as search words instead of the full password path.
Passwords whose paths contain all given words (as substrings) are
listed.  If only one match is found, the orignal "show" command is
executed with the found path.
